### PR TITLE
POST using diferent content type

### DIFF
--- a/src/Restful/Parser.php
+++ b/src/Restful/Parser.php
@@ -123,7 +123,7 @@ class Parser {
      */
     public function parse()
     {
-        if( $this->method === 'post' )
+        if( $this->method === 'post' && strpos( $this->ctype, 'form-' ) !== false )
         {
             $_REQUEST = array_merge( $_GET, $_POST );
             return true;


### PR DESCRIPTION
The most common `Content-Type` is `application/x-www-form-urlencoded` or `multipart/form-data` but many applications using REST/RESTful use `application/json;charset=utf-8` (some others `text/xml;charset=utf-8`) to send post data to server api.